### PR TITLE
Bug fixes

### DIFF
--- a/forgen.rb
+++ b/forgen.rb
@@ -300,11 +300,7 @@ def make_virtualbox_vm(options)
   @colour.notify "Ensuring following commands run from directory '#{options[:project_dir]}/Vagrantfile'"
   @colour.notify 'Executing vagrant up (this may take a while)'
 
-  if options.has_key? :debug
-    system "cd '#{options[:project_dir]}' && vagrant up --debug"
-  else
-    system "cd '#{options[:project_dir]}' && vagrant up"
-  end
+  system "cd '#{options[:project_dir]}' && vagrant up #{'--debug' if options[:debug]} #{'--no-color' if options[:disable_colour]}"
 
   return options
 end

--- a/lib/templates/Puppetfile.erb
+++ b/lib/templates/Puppetfile.erb
@@ -4,9 +4,8 @@
 forge "https://forgeapi.puppetlabs.com"
 
 # Load Build modules
-# mod 'puppetlabs-powershell', '2.1.0'
+mod 'puppetlabs-chocolatey'
 mod 'puppetlabs-stdlib', '4.14.0'
-# mod 'puppetlabs-windows', '3.0.0'
 
 # Load custom modules
 <% @config_modules.each do | provisioner, modules | -%>

--- a/lib/templates/Vagrantfile.erb
+++ b/lib/templates/Vagrantfile.erb
@@ -19,8 +19,10 @@ Vagrant.configure("2") do |config|
   # config.vm.box_version = #{Version number, defaults to latest}
   # config.vm.communicator = 'Default ssh' / 'winrm' for windows guests
   config.vm.communicator = 'winrm'
-  config.vm.boot_timeout = 600
-  config.vm.graceful_halt_timeout = 600
+  # config.vm.boot_timeout = 600
+  config.vm.boot_timeout = 10000
+  # config.vm.graceful_halt_timeout = 600
+  config.vm.graceful_halt_timeout = 10000
   # config.vm.graceful_halt_timeout = Default '60' seconds
   # config.vm.guest = Defaults to ':linux' / windows ':windows'
   config.vm.guest = :windows


### PR DESCRIPTION
Puppetfile.erb:
Removed puppetlabs-windows due to dependency download failure, replaced with puppetlabs-chocolatey dependency for some needed features.

Vagrantfile.erb:
Increased vagrant boot timeout and vagrant halt timeout to ensure provisioning completes without vagrant errors.

forgen.rb:
Condensed vagrant debug command into one line to optimize code.